### PR TITLE
Docker 環境設定

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,23 @@ FROM ubuntu:latest
 RUN apt-get update && apt-get install -y \
 	sudo \
 	wget \
-	vim
+	vim \
+	zip \
+	unzip
 
 # root権限意外でも扱えるようにする 共有サーバとか
 WORKDIR /opt
 
-# 任意のversionをinstall
+# Anaconda3 任意のversionをinstall
 RUN wget https://repo.continuum.io/archive/Anaconda3-2021.05-Linux-x86_64.sh && \
 	sh Anaconda3-2021.05-Linux-x86_64.sh -b -p /opt/anaconda3 && \
 	# インストール後必要ないから削除
 	rm -f Anaconda3-2021.05-Linux-x86_64.sh
+
+# aws CLI: https://docs.aws.amazon.com/ja_jp/cli/latest/userguide/install-cliv2-linux.html
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install
 
 ENV PATH /opt/anaconda3/bin:$PATH
 RUN pip install --upgrade pip

--- a/api/storage.ipynb
+++ b/api/storage.ipynb
@@ -2,17 +2,18 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 11,
    "id": "b9ff1fc9-59fb-4468-bc44-693e2b7155aa",
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
     "import boto3"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 16,
    "id": "ce8e0ff8-d28c-4ef7-8503-80a60064176e",
    "metadata": {},
    "outputs": [],
@@ -22,18 +23,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 13,
+   "id": "f1dc1da5-c42d-4773-a44c-e1f6214221b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket_name = 'testbucket-yyyymmdd'\n",
+    "region = 'ap-northeast-1'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
    "id": "91e1c56e-47b7-4ed5-815b-4ecabe35e110",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# s3.create_bucket('testbucket')"
+    "# s3.create_bucket(\n",
+    "#     Bucket=bucket_name,\n",
+    "#     CreateBucketConfiguration={'LocationConstraint': region}\n",
+    "# )"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f1dc1da5-c42d-4773-a44c-e1f6214221b3",
+   "id": "de37d98b-de6d-4b09-871a-893dd059fc42",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+
+services:
+  web:
+    platform: linux/amd64
+    build: .
+    ports:
+      - '8888:8888'
+
+    # mount先指定
+    volumes:
+      - '.:/work'
+
+    tty: true
+    stdin_open: true


### PR DESCRIPTION
## About
Docker (Linux 環境) で aws コンソールを使用できるように設定する

## Task
- `aws CLI` install を追加
- `docker-compose.yml`を追加
- `create_bucket` で疎通確認

## CMD
docker container で key を設定

```bash
# 実行コマンド
$ aws configure

# 順に値を入力
AWS Access Key ID [None]: <Access Key ID> # IAM の　key
AWS Secret Access Key [None]: <Secret Access Key> # IAM の　key
Default region name [None]: <default region name>
Default output format [None]: json # 任意
```

## Reference
- [Linux での AWS CLI バージョン 2 のインストール、更新、アンインストール](https://docs.aws.amazon.com/ja_jp/cli/latest/userguide/install-cliv2-linux.html)
- [aws configure](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/quickstart.html#configuration)