### PR TITLE
選択した Directory 配下のファイルをリストで取得できるように調整

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ dmypy.json
 
 # data
 data/
+tmp/

--- a/api/controllers/storage_controller.py
+++ b/api/controllers/storage_controller.py
@@ -1,4 +1,5 @@
 import os
+
 from dotenv import load_dotenv
 
 from config import const
@@ -14,15 +15,14 @@ def s3_storage_management():
 
     management_storage = storage.Storage(client=const.CLIENT, bucket_name=const.BUCKET_NAME, region=region)
 
-    # TODO: 指定 Directory のファイルを格納する
-    data_list = ['user.sql', 'user.json']
+    data_list = management_storage.get_file_data(base_path='data')
 
     if const.BUCKET_CREATE:
         management_storage.create_bucket()
 
     if const.UPLOAD:
         for data in data_list:
-            management_storage.upload_data(bucket_name=const.BUCKET_NAME, upload_data=f"data/{data}")
+            management_storage.upload_data(bucket_name=const.BUCKET_NAME, upload_data=data)
 
     if const.DOWNLOAD:
         for data in data_list:
@@ -30,7 +30,7 @@ def s3_storage_management():
 
     if const.DELETE:
         for data in data_list:
-            management_storage.delete_data(bucket_name=const.BUCKET_NAME, delete_data=f"data/{data}")
+            management_storage.delete_data(bucket_name=const.BUCKET_NAME, delete_data=data)
 
     if const.BUCKET_DELETE:
         management_storage.delete_all_buckets()

--- a/api/models/storage.py
+++ b/api/models/storage.py
@@ -3,6 +3,7 @@ import glob
 
 from botocore.exceptions import ClientError
 from pathlib import Path
+from typing import List
 
 from config import const, logger_tool
 
@@ -27,17 +28,25 @@ class Storage(object):
         self.region = region
 
     @staticmethod
-    def get_file_data(base_path='data', sub_path=None):
+    def get_file_data(base_path='data', sub_path=None) -> List:
         """ dataが格納されているファイルを取得する
+
+        ExSample
+        ---------
+        # only base_path
+        data_list = management_storage.get_file_data(base_path='data')
+
+        # test sub_path
+        data_list = management_storage.get_file_data(base_path='data', sub_path='test1')
 
         params
         ------
-            base_path(str): 最上位の directory
+            base_path(str): base directory
             sub_path(str): sub directory
 
         return
         ------
-            指定 directory にあるファイル一覧を取得した結果を返す
+            取得したファイルを list で返す
         """
         if sub_path:
             return glob.glob(f"{base_path}/{sub_path}/*.*")

--- a/src/storage.ipynb
+++ b/src/storage.ipynb
@@ -2,16 +2,21 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 38,
    "id": "b9ff1fc9-59fb-4468-bc44-693e2b7155aa",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
+    "import sys\n",
     "\n",
     "import boto3\n",
     "\n",
     "from dotenv import load_dotenv \n",
+    "\n",
+    "# 親階層の読み込み　\n",
+    "# from ..api import ... では、package を読み込めなかったため\n",
+    "sys.path.append('../')\n",
     "\n",
     "import api.controllers.storage_controller"
    ]
@@ -26,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 39,
    "id": "9c9374b1-77f5-419c-bc0e-90e9010dda18",
    "metadata": {},
    "outputs": [],
@@ -47,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 40,
    "id": "91e1c56e-47b7-4ed5-815b-4ecabe35e110",
    "metadata": {},
    "outputs": [],
@@ -68,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 41,
    "id": "f56c9e6c-6f01-43c3-bbdb-36007722e392",
    "metadata": {},
    "outputs": [],
@@ -87,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 42,
    "id": "cbea844a-a401-4fd8-985a-69385b677bd3",
    "metadata": {},
    "outputs": [
@@ -106,7 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f42e0566-6a9c-4327-9040-e3975a6a9b58",
+   "id": "3dd15475-9692-4f90-9a63-e3917ec59606",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -114,7 +119,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99b98e13-debf-4c76-aca5-1d5f9f841e0b",
+   "id": "88b350ad-cc0b-41bb-a55d-fa09314a9a76",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/storage.ipynb
+++ b/src/storage.ipynb
@@ -14,8 +14,8 @@
     "\n",
     "from dotenv import load_dotenv \n",
     "\n",
-    "# 親階層の読み込み　\n",
-    "# from ..api import ... では、package を読み込めなかったため\n",
+    "# 親階層のファイル読み込み　\n",
+    "# from ..api import ... では、ファイル読み込みできなかったため\n",
     "sys.path.append('../')\n",
     "\n",
     "import api.controllers.storage_controller"
@@ -107,14 +107,6 @@
    "source": [
     "api.controllers.storage_controller.s3_storage_management()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3dd15475-9692-4f90-9a63-e3917ec59606",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## About
タイトル通り

## Task
- `glob` で sub directory までファイル取得できるように調整
- JupyterLab は、`sys.path.append('../')`で親階層からファイル読み込みできるように調整
- download directory の ハードコートをパラメータに入れるよう調整