### PR TITLE
pytest training test SystemExit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ moto==2.2.8
 mysql-client==0.0.1
 mysql-connector-python==8.0.27
 python-dotenv==0.19.0
+botocore~=1.21.46
+pytest~=6.2.5

--- a/test/test_message.py
+++ b/test/test_message.py
@@ -1,33 +1,45 @@
-import logging
 import pytest
 import sys
-import os
+
 from logging import DEBUG, INFO, ERROR, getLogger
 
-logger = getLogger('test')
+# Logger generation
+logger = getLogger(__name__)
 
 
 class Msg(object):
+    """ Sample Code """
 
     def __init__(self):
-        self.moon = 'moon'
+        pass
 
     def division(self, num):
+        """ divide
+
+        params
+        ------
+          num(int): Number to put in denominator
+
+        return
+        ------
+          Return the result of division
+
+        """
         try:
             return 1 / num
         except ZeroDivisionError:
             print('moooon')
-            logger.error('error', extra={'add_iti onal data': 'error msg'})
+            logger.error('error', extra={'add initial data': 'error msg'})
             sys.exit(200)
 
     def log_debug(self):
-        logger.debug('debug', extra={'add_iti onal data': 'debug msg'})
+        logger.debug('debug', extra={'add initial data': 'debug msg'})
 
     def log_info(self):
-        logger.info('info', extra={'add_iti o nal data': 'info msg'})
+        logger.info('info', extra={'add initial data': 'info msg'})
 
     def log_err(self):
-        logger.error('error', extra={'add_iti o nal data': 'error msg'})
+        logger.error('error', extra={'add initial data': 'error msg'})
         sys.exit(1)
 
     def exit(self):
@@ -41,6 +53,9 @@ class Msg(object):
 
 
 class TestMsg(object):
+    """ Test Code.
+      Essentially, create a separate file as a test file.
+    """
 
     @classmethod
     def setup_class(cls):
@@ -64,14 +79,14 @@ class TestMsg(object):
 
         assert out == 'moooon\n'
         assert err is ''
-        assert [('test', ERROR, 'error')] == caplog.record_tuples
+        assert [('test.test_message', ERROR, 'error')] == caplog.record_tuples
         assert e.value.code == 200
 
     def test_log_debug(self, caplog):
         caplog.set_level(DEBUG)
 
         self.m.log_debug()
-        assert [('test', DEBUG, 'debug')] == caplog.record_tuples
+        assert [('test.test_message', DEBUG, 'debug')] == caplog.record_tuples
 
     def test_log_err_sys_exit(self):
         with pytest.raises(SystemExit) as e:
@@ -82,7 +97,6 @@ class TestMsg(object):
         """ Test SystemExit """
         with pytest.raises(SystemExit) as e:
             self.m.exit()
-
         assert e.value.code == 1
 
     def test_exit_system_exit_202(self):

--- a/test/test_test.py
+++ b/test/test_test.py
@@ -1,0 +1,79 @@
+import logging
+import pytest
+import sys
+import os
+from logging import DEBUG, INFO, ERROR, getLogger
+
+logger = getLogger('test')
+
+
+class Msg(object):
+
+    def __init__(self):
+        self.moon = 'moon'
+
+    def moon_(self):
+        try:
+            r = 1 / 0
+        except:
+            print('moooon')
+            sys.exit(200)
+
+    def log_debug(self):
+        logger.debug('debug', extra={'add_iti onal data': 'debug msg'})
+
+    def log_info(self):
+        logger.info('info', extra={'add_iti o nal data': 'info msg'})
+
+    def log_err(self):
+        logger.error('error', extra={'add_iti o nal data': 'error msg'})
+
+    def exit(self):
+        sys.exit(1)
+
+    def exit_202(self):
+        sys.exit(202)
+
+
+class TestMsg(object):
+
+    @classmethod
+    def setup_class(cls):
+        print('start')
+        cls.m = Msg()
+
+    @classmethod
+    def teardown_class(cls):
+        print('end')
+
+    def test_moon_exit(self):
+        with pytest.raises(SystemExit):
+            self.m.moon_()
+
+    def test_moon_print(self, capfd):
+        with pytest.raises(SystemExit):
+            self.m.moon_()
+            out, err = capfd.readouterr()
+            assert out == 'aaa\nbbb\n'
+            assert err is ''
+
+    def test_moon_log_error(self, caplog):
+        caplog.set_level(DEBUG)
+
+        self.m.log_debug()
+        assert [('test', DEBUG, 'debug')] == caplog.record_tuples
+        # assert caplog.records[0].extra == 'info'
+
+    def test_exit_system_exit(self):
+        """ Test SystemExit """
+        with pytest.raises(SystemExit) as e:
+            self.m.exit()
+        # e.value で SystemExit を参照できる
+        assert e.value.code == 1
+
+    def test_exit_system_exit_202(self):
+        """ Test SystemExit """
+        with pytest.raises(SystemExit) as e:
+            self.m.exit_202()
+        # e.value で SystemExit を参照できる
+        assert e.value.code == 202

--- a/test/test_test.py
+++ b/test/test_test.py
@@ -15,7 +15,7 @@ class Msg(object):
     def division(self, num):
         try:
             return 1 / num
-        except:
+        except ZeroDivisionError:
             print('moooon')
             logger.error('error', extra={'add_iti onal data': 'error msg'})
             sys.exit(200)
@@ -58,12 +58,14 @@ class TestMsg(object):
     def test_moon_print(self, caplog, capfd):
         caplog.set_level(ERROR)
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit) as e:
             self.m.division(0)
         out, err = capfd.readouterr()
+
         assert out == 'moooon\n'
-        assert [('test', ERROR, 'error')] == caplog.record_tuples
         assert err is ''
+        assert [('test', ERROR, 'error')] == caplog.record_tuples
+        assert e.value.code == 200
 
     def test_log_debug(self, caplog):
         caplog.set_level(DEBUG)

--- a/test/test_test.py
+++ b/test/test_test.py
@@ -12,11 +12,12 @@ class Msg(object):
     def __init__(self):
         self.moon = 'moon'
 
-    def moon_(self):
+    def division(self, num):
         try:
-            r = 1 / 0
+            return 1 / num
         except:
             print('moooon')
+            logger.error('error', extra={'add_iti onal data': 'error msg'})
             sys.exit(200)
 
     def log_debug(self):
@@ -27,6 +28,7 @@ class Msg(object):
 
     def log_err(self):
         logger.error('error', extra={'add_iti o nal data': 'error msg'})
+        sys.exit(1)
 
     def exit(self):
         sys.exit(1)
@@ -34,46 +36,64 @@ class Msg(object):
     def exit_202(self):
         sys.exit(202)
 
+    def exit_203(self):
+        sys.exit(203)
+
 
 class TestMsg(object):
 
     @classmethod
     def setup_class(cls):
-        print('start')
+        print('\n*** start ***\n')
         cls.m = Msg()
 
     @classmethod
     def teardown_class(cls):
-        print('end')
+        print('\n\n*** end ***')
 
     def test_moon_exit(self):
         with pytest.raises(SystemExit):
-            self.m.moon_()
+            self.m.division(0)
 
-    def test_moon_print(self, capfd):
+    def test_moon_print(self, caplog, capfd):
+        caplog.set_level(ERROR)
+
         with pytest.raises(SystemExit):
-            self.m.moon_()
-            out, err = capfd.readouterr()
-            assert out == 'aaa\nbbb\n'
-            assert err is ''
+            self.m.division(0)
+        out, err = capfd.readouterr()
+        assert out == 'moooon\n'
+        assert [('test', ERROR, 'error')] == caplog.record_tuples
+        assert err is ''
 
-    def test_moon_log_error(self, caplog):
+    def test_log_debug(self, caplog):
         caplog.set_level(DEBUG)
 
         self.m.log_debug()
         assert [('test', DEBUG, 'debug')] == caplog.record_tuples
-        # assert caplog.records[0].extra == 'info'
+
+    def test_log_err_sys_exit(self):
+        with pytest.raises(SystemExit) as e:
+            self.m.log_err()
+        assert e.value.code == 1
 
     def test_exit_system_exit(self):
         """ Test SystemExit """
         with pytest.raises(SystemExit) as e:
             self.m.exit()
-        # e.value で SystemExit を参照できる
+
         assert e.value.code == 1
 
     def test_exit_system_exit_202(self):
         """ Test SystemExit """
         with pytest.raises(SystemExit) as e:
             self.m.exit_202()
-        # e.value で SystemExit を参照できる
+
+        assert e.type == SystemExit
         assert e.value.code == 202
+
+    def test_exit_pytest_fix(self):
+        with pytest.raises(SystemExit) as e:
+            self.m.exit_203()
+
+        assert e.type == SystemExit
+        assert e.value.code == 203


### PR DESCRIPTION
## About
- pytest training


## Task
- pytest sysexit Trial and error
- Test using the pytest fixture
   - caplog
   - capfd

## Note
- L82: Error code 
The number of the error code is reserved, and the test will pass even if it is 40.

```python
# [(<logger name>, <logger level num>, <message> )]
>> [('test', 40, 'error')]
```


## Reference
- [[Pytest] pytest 入門、テストコードを書く方法](https://webbibouroku.com/Blog/Article/pytest#outline__3_2)